### PR TITLE
Support differentiable datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ benchmarks ++= Seq(
         ),
         // The set of file to run each command on
         tasks = Seq(Tasks("APAEWD840", Seq("ewd840/APAEWD840.tla"))),
+        // Optional group ID used to group results into disjoint sets
+        // in reports. Most benchmarks can simply ommit the group id.
+        group = Some("group-id")
       ),
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val site = (project in file("src/site"))
       "0.22.0",
       "0.23.0",
       "0.24.0",
+      "0.25.0",
     ),
     benchmarksIndexFile := Some(baseDirectory.value / "index.html"),
   )

--- a/performance/build.sbt
+++ b/performance/build.sbt
@@ -15,7 +15,7 @@ benchmarks ++= Seq(
 )
 
 def suiteForEncoding(name: String, specs: Seq[String]) = {
-  val defaultMaxLength = 8
+  val defaultMaxLength = 4
   val maxLength =
     // We default to the empty string for fallback so that we
     // can gracefuly the case when the variable is set environment
@@ -45,6 +45,7 @@ def suiteForEncoding(name: String, specs: Seq[String]) = {
       timelimit = "2h",
       tasks = Seq(Tasks(s"${name}-${encoding}", specs)),
       cmds = lengths.map(checkCmd(encoding, _)),
+      group = Some(encoding),
     )
   }
 

--- a/performance/build.sbt
+++ b/performance/build.sbt
@@ -15,7 +15,7 @@ benchmarks ++= Seq(
 )
 
 def suiteForEncoding(name: String, specs: Seq[String]) = {
-  val defaultMaxLength = 4
+  val defaultMaxLength = 8
   val maxLength =
     // We default to the empty string for fallback so that we
     // can gracefuly the case when the variable is set environment

--- a/project/sbt-benchexec/BenchExec.scala
+++ b/project/sbt-benchexec/BenchExec.scala
@@ -144,7 +144,6 @@ object BenchExec extends AutoPlugin {
       case (group, results) =>
         results.sorted.zipWithIndex.map { case (f, i) =>
           val id = s"${group}-${i}"
-          println(s">>>> ID: ${id}")
           <result id={id} filename={f}/>
         }
     }

--- a/project/sbt-benchexec/BenchExec.scala
+++ b/project/sbt-benchexec/BenchExec.scala
@@ -380,18 +380,26 @@ h1 {
         .open(resultPath.toFile)
         .all()
         .drop(3)
-        .foreach {
-          case task :: id :: status :: cputime :: walltime :: memory :: Nil => {
-            cputimeReport.addResult(version, s"${task}:${id}", cputime.toDouble)
-            walltimeReport.addResult(
-              version,
-              s"${task}:${id}",
-              walltime.toDouble,
-            )
-            memoryReport.addResult(version, s"${task}:${id}", memory.toDouble)
+        .foreach { row =>
+          // We drop any empty cells, to cope with benchexec's strange way of reporting
+          // its data in CSVs. See https://github.com/sosy-lab/benchexec/issues/827
+          row.filter(_ != "") match {
+            case task :: id :: status :: cputime :: walltime :: memory :: Nil => {
+              cputimeReport.addResult(
+                version,
+                s"${task}:${id}",
+                cputime.toDouble,
+              )
+              walltimeReport.addResult(
+                version,
+                s"${task}:${id}",
+                walltime.toDouble,
+              )
+              memoryReport.addResult(version, s"${task}:${id}", memory.toDouble)
+            }
+            case row =>
+              throw new RuntimeException(s"Invalid report data row: ${row}")
           }
-          case row =>
-            throw new RuntimeException(s"Invalid report data row: ${row}")
         }
     }
 


### PR DESCRIPTION
This lets us define groups to separate results in a benchmark suite into disjoint sets. This is helpful for improving the reporting on encoding benchmarks, and closes the last point in informalsystems/apalache#1658