### PR TITLE
Improvements to enable parallel execution of experiments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     # Allows manually triggering release
     inputs:
       release_version:
-        description: "Version/branch to benchmark. See README.md for syntax. (defaults to unstable branch)"
+        description: "Version/branch to benchmark. See README.md for syntax. (defaults to main branch)"
         required: false
         default: ""
       filter_experiments:
@@ -18,14 +18,14 @@ on:
         default: ""
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Automatically run the benchmarks on unstable every Saturday
+    # Automatically run the benchmarks on main every Saturday
     # See https://crontab.guru/#0_0_*_*_6
     - cron: "0 0 * * 6"
 
 name: benchmarks
 
 env:
-  VERSION: ${{ github.event.inputs.release_version || '#unstable' }}
+  VERSION: ${{ github.event.inputs.release_version || '#main' }}
   FILTER_EXPERIMENTS: ${{ github.event.inputs.filter_experiments }}
   ENCODING_COMPARISON_MAX_LENGTH: ${{ github.event.inputs.encoding_comparison_max_length }}
   # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ping-igor.yml
+++ b/.github/workflows/ping-igor.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Automatically run the benchmarks on unstable every Saturday
+    # Automatically run the benchmarks on main every Saturday
     # See https://crontab.guru/#0_0_*_*_6
     - cron: "0 0 * * 6"
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ sbt 'set apalacheVersion := "#main"; benchmarksReport'
 sbt 'set apalacheVersion := "#c1ed9ef1596bb6e8df6b4f77a8335448eebfa80f"; benchmarksReport'
 ```
 
+#### Build and link a version of Apalache
+
+`apalache-bench` will try not to rebuild and relink Apalache if nothing has
+changed. You can ensure that the build and linking of the configured Apalache is
+performed via
+
+``` sh
+sbt apalacheEnableVersion
+```
+
+This will ensure the configured Apalche version is downloaded, built, and that
+the executable is available for subsequent benchmarks in that shell session.
+
 ### For a specific project
 
 The general recipe for running benchmarks and generating reports for a specific project is:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For a complete working example, see [performance/build.sbt](performance/build.sb
 
 # Running the benchmarks
 
-The benchmarks run against the latest `unstable` branch every weekend, and the
+The benchmarks run against the latest `main` branch every weekend, and the
 results are published. The following instructions are for if you want to
 manually run the benchmarks.
 
@@ -196,7 +196,7 @@ Prefix the branch name or commit ref with `#`. E.g.:
 
 ``` sh
 # For a branch
-sbt 'set apalacheVersion := "#unstable"; benchmarksReport'
+sbt 'set apalacheVersion := "#main"; benchmarksReport'
 # For a specific commit
 sbt 'set apalacheVersion := "#c1ed9ef1596bb6e8df6b4f77a8335448eebfa80f"; benchmarksReport'
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / sbtVersion := "1.6.1"
 ThisBuild / scalaVersion := "2.13.6"
 ThisBuild / organization := "systems.informal"
 
-ThisBuild / apalacheVersion := "#unstable"
+ThisBuild / apalacheVersion := "#main"
 ThisBuild / benchmarksToolVersion := apalacheEnableVersion.value
 
 lazy val performance = (project in file("performance"))
@@ -22,7 +22,7 @@ lazy val root = (project in file("."))
     performance,
     parametric,
     endive,
-    examples
+    examples,
   )
 
 // Configure GH pages site

--- a/project/sbt-apalache/Apalache.scala
+++ b/project/sbt-apalache/Apalache.scala
@@ -82,6 +82,9 @@ object Apalache extends AutoPlugin {
   private def fetchBranch(destDir: File) =
     s"git -C ${destDir} pull"
 
+  private def gitRev(destDir: File) =
+    s"git -C ${destDir} rev-parse --short HEAD"
+
   lazy val apalacheFetchImpl: Def.Initialize[Task[File]] = Def.task {
     val log = streams.value.log
 
@@ -91,27 +94,42 @@ object Apalache extends AutoPlugin {
 
     version match {
       case Version.Release(version) => {
-        IO.createDirectory(destDir)
-        val destTar = destDir / "apalache.tgz"
-        log.info(s"Fetching Apalache release version ${version} to ${destDir}")
-        Execute.succeed(Process(fetchByVersion(version, destTar)), log)
-        log.info(s"Unpacking Apalache to ${destDir}")
-        Execute.succeed(
-          Process(s"tar zxvf ${destTar} --strip-components=1 -C ${destDir}"),
-          log,
-        )
+        if (destDir.exists()) {
+          log.info(s"Apalache version ${version} is already fetched")
+        } else {
+          IO.createDirectory(destDir)
+          val destTar = destDir / "apalache.tgz"
+          log.info(
+            s"Fetching Apalache release version ${version} to ${destDir}"
+          )
+          Execute.succeed(Process(fetchByVersion(version, destTar)), log)
+          log.info(s"Unpacking Apalache to ${destDir}")
+          Execute.succeed(
+            Process(s"tar zxvf ${destTar} --strip-components=1 -C ${destDir}"),
+            log,
+          )
+        }
       }
       case Version.Branch(version) => {
-        if (destDir.exists()) {
+        val shouldBuild = if (destDir.exists()) {
+          val prevRev = Process(gitRev(destDir)) !! log
           log.info(s"Updating Apalache branch ${version} in ${destDir}")
           Process(fetchBranch(destDir)) ! log
+          val nextRev = Process(gitRev(destDir)) !! log
+          prevRev != nextRev
         } else {
           IO.createDirectory(destDir)
           log.info(s"Fetching Apalache branch ${version} to ${destDir}")
           Execute.succeed(Process(fetchByBranch(version, destDir)), log)
+          true
         }
-        log.info("Building Apalache")
-        Execute.succeed(Process(s"make -C ${destDir} package"), log)
+        if (shouldBuild) {
+          log.info("Building Apalache")
+          Execute.succeed(Process(s"make -C ${destDir} package"), log)
+        } else {
+          log.info("Apalache repo up to date, no need to rebuild")
+        }
+
       }
     }
     destDir

--- a/project/sbt-apalache/Apalache.scala
+++ b/project/sbt-apalache/Apalache.scala
@@ -59,7 +59,7 @@ object Apalache extends AutoPlugin {
   import autoImport._
 
   override lazy val globalSettings: Seq[Setting[_]] = Seq(
-    apalacheVersion := "#unstable"
+    apalacheVersion := "#main"
   )
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(

--- a/project/sbt-benchexec/BenchExec.scala
+++ b/project/sbt-benchexec/BenchExec.scala
@@ -18,6 +18,7 @@ import io.circe.syntax._
 import sbt._
 import Keys._
 import java.io.InputStream
+import java.util.UUID
 
 object BenchExec extends AutoPlugin {
   val Chart = LongitudinalChart
@@ -105,8 +106,10 @@ object BenchExec extends AutoPlugin {
       }
     }
 
-  private def timestamp() =
-    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(new Date())
+  private def timestamp() = {
+    val stamp = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(new Date())
+    s"${stamp}-${UUID.randomUUID()}"
+  }
 
   lazy val benchexecRun: Def.Initialize[Task[Seq[Bench.T[Bench.Executed]]]] =
     Def.task {


### PR DESCRIPTION
Closes #76

- Adds some logic so we don't rebuild Apalache if the version or commit hasn't changed
- Add UUIDs to file name so they don't clobber each other

I've tried this with `parallel` and it seems to be working. It's a good idea to run `sbt apalacheEnableVersion` with the desired version prior to trying the experiments to be sure it's built.

@rodrigo7491 we can sync up when you have time to give it a try and see if it works well enough for our current purposes.